### PR TITLE
增加连接远程服务器可传入IP地址字符串

### DIFF
--- a/lib/MQTTClient/MQTTESP8266.c
+++ b/lib/MQTTClient/MQTTESP8266.c
@@ -118,9 +118,12 @@ int ConnectNetwork(Network* n, char* host, int port)
     struct sockaddr_in addr;
     int ret;
 
-    if (host2addr(host, &(addr.sin_addr)) != 0)
+    if (inet_aton(host, &(addr.sin_addr)) == 0)
     {
-        return -1;
+        if (host2addr(host, &(addr.sin_addr)) != 0)
+        {
+            return -1;
+        }
     }
 
     addr.sin_family = AF_INET;


### PR DESCRIPTION
修改lib/MQTTESP8266.c中的ConnectNetwork函数，传入host参数时，可以传入IP地址的字符串类型，例如：“127.0.0.1”